### PR TITLE
Implement Display trait for Deck struct

### DIFF
--- a/src/gameplay.rs
+++ b/src/gameplay.rs
@@ -225,6 +225,7 @@ pub type Flop = CardsCombined<3>;
 
 pub mod display {
     use super::*;
+    use headsup::Deck;
 
     #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
     pub struct SuitDisplay {
@@ -295,6 +296,33 @@ pub mod display {
             };
             for (i, card) in self.cards.iter().enumerate() {
                 if i > 0 {
+                    write!(f, "{}", delimiter)?;
+                }
+                write!(f, "{}", card.display(self.mode))?;
+            }
+            Ok(())
+        }
+    }
+    
+    #[derive(Debug, PartialEq, Eq, Clone, Copy, Hash)]
+    pub struct DeckDisplay {
+        pub(super) deck: Deck,
+        pub(super) mode: DisplayMode,
+    }
+    
+    impl Display for DeckDisplay {
+        fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+            let cards_per_row = 13;
+            let delimiter = if self.mode == DisplayMode::Ascii {
+                " "
+            } else {
+                "  "
+            };
+            
+            for (i, card) in self.deck.deal().enumerate() {
+                if i > 0 && i % cards_per_row == 0 {
+                    writeln!(f)?;
+                } else if i > 0 {
                     write!(f, "{}", delimiter)?;
                 }
                 write!(f, "{}", card.display(self.mode))?;

--- a/src/gameplay/headsup.rs
+++ b/src/gameplay/headsup.rs
@@ -226,6 +226,10 @@ impl Deck {
     pub fn deal(&self) -> IntoIter<Card, 52> {
         self.0.into_iter()
     }
+    
+    pub fn display(self, mode: DisplayMode) -> DeckDisplay {
+        DeckDisplay { deck: self, mode }
+    }
 }
 
 // todo: Dealer

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,6 +16,13 @@ fn main() {
 
     let mut deck = Deck::default().shuffled();
 
+    // Display entire deck using the new display trait
+    println!("Deck display (ColoredEmoji):");
+    println!("{}", deck.display(DisplayMode::ColoredEmoji));
+    println!();
+
+    // Original card-by-card display
+    println!("Card-by-card display (ColoredEmoji):");
     for (i, card) in deck.deal().enumerate() {
         match i % 5 {
             0 if i != 0 => println!(),
@@ -27,8 +34,13 @@ fn main() {
     }
 
     deck.shuffle();
+    println!("\n");
+
+    println!("Deck display (ColoredUnicode):");
+    println!("{}", deck.display(DisplayMode::ColoredUnicode));
     println!();
 
+    println!("Card-by-card display (ColoredUnicode):");
     for (i, card) in deck.deal().enumerate() {
         match i % 5 {
             0 => println!(),
@@ -40,8 +52,13 @@ fn main() {
     }
 
     deck.shuffle();
+    println!("\n");
+
+    println!("Deck display (Unicode):");
+    println!("{}", deck.display(DisplayMode::Unicode));
     println!();
 
+    println!("Card-by-card display (Unicode):");
     for (i, card) in deck.deal().enumerate() {
         match i % 5 {
             0 => println!(),
@@ -53,8 +70,13 @@ fn main() {
     }
 
     deck.shuffle();
+    println!("\n");
+
+    println!("Deck display (Ascii):");
+    println!("{}", deck.display(DisplayMode::Ascii));
     println!();
 
+    println!("Card-by-card display (Ascii):");
     for (i, card) in deck.deal().enumerate() {
         match i % 5 {
             0 => println!(),

--- a/tests/deck_display.rs
+++ b/tests/deck_display.rs
@@ -1,0 +1,33 @@
+use pokerbot::gameplay::{DisplayMode, headsup::Deck};
+use std::fmt::Write;
+
+#[test]
+fn test_deck_display() {
+    let deck = Deck::default();
+    
+    // Test Ascii display
+    let display = deck.display(DisplayMode::Ascii);
+    let mut output = String::new();
+    write!(&mut output, "{}", display).unwrap();
+    
+    // Verify that the output contains all 52 cards
+    assert!(output.contains("As"));
+    assert!(output.contains("Kh"));
+    assert!(output.contains("Qd"));
+    assert!(output.contains("Jc"));
+    assert!(output.contains("2s"));
+    
+    // Verify that the output has multiple lines (due to cards_per_row)
+    assert!(output.contains('\n'));
+    
+    // Test Unicode display
+    let display = deck.display(DisplayMode::Unicode);
+    let mut output = String::new();
+    write!(&mut output, "{}", display).unwrap();
+    
+    // Verify that the output contains Unicode symbols
+    assert!(output.contains("♠"));
+    assert!(output.contains("♥"));
+    assert!(output.contains("♦"));
+    assert!(output.contains("♣"));
+}


### PR DESCRIPTION
This PR implements the Display trait for the Deck struct, allowing for easy formatting and display of a deck of cards in various display modes (Ascii, Unicode, ColoredUnicode, ColoredEmoji).

## Changes:
1. Added a `display` method to the `Deck` struct that returns a `DeckDisplay` struct
2. Implemented the `DeckDisplay` struct in the display module
3. Implemented the `Display` trait for `DeckDisplay`
4. Added tests to verify the implementation works correctly
5. Updated the main.rs file to demonstrate the use of the new display method

Fixes #1

@czy-29 can click here to [continue refining the PR](https://app.all-hands.dev/conversations/4852d4dfa83b4a92ab5c371bd66da2b4)